### PR TITLE
cda-validator: corrige error al verificar dto

### DIFF
--- a/cda-validator/controller/verificaCDA.ts
+++ b/cda-validator/controller/verificaCDA.ts
@@ -133,15 +133,19 @@ export async function verificar(registro, pacienteAndes) {
         notError = false;
         msgError = 'La prestación no existe';
     }
+    if (!registro.fecha) {
+        notError = false;
+        msgError = 'El registro no posee fecha de registro o id';
+    }
 
-    notError = registro.fecha ? true : false;
-    notError = registro.id ? true : false;
+    if (!registro.id) {
+        notError = false;
+        msgError = 'El registro no posee fecha de registro o id';
+    }
 
     if (notError) {
         dto['fecha'] = moment(registro.fecha).toDate();
         dto['id'] = registro.id;
-    } else {
-        msgError = 'El registro no posee fecha de registro o id';
     }
 
     if (notError) {


### PR DESCRIPTION
### Funcionalidad desarrollada 
1. Corrige un bug al verificar datos antes de enviarlo a la API. Quedaban todos como validos.


### UserStory llegó a completarse 
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [ ] Si
- [x] No

 