### PR TITLE
andesMicroservicios: Corrección regex para que acepte urls con espacios.

### DIFF
--- a/cda-laboratorios/controller/import-labs.ts
+++ b/cda-laboratorios/controller/import-labs.ts
@@ -87,7 +87,7 @@ function donwloadFileHeller(idProtocolo, year) {
             return response.on('data', (buffer) => {
                 const resp = buffer.toString();
 
-                const regexp = /10.1.104.37\/resultados_omg\/([0-9\-\_]*).pdf/;
+                const regexp = /10.1.104.37\/resultados_omg\/([0-9\s\-\_]*).pdf/;
                 const match = resp.match(regexp);
                 if (match && match[1]) {
                     return downloadFile(wsSalud.hellerFS + match[1] + '.pdf').then((_resp) => {


### PR DESCRIPTION
### Requerimiento
* URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento

### Funcionalidad desarrollada 
Se modifica la funcionalidad de la regex para que acepte las url que tiene el Heller, donde las llamadas al webserivce retornan con pdf que tienen la ruta con espacios en blanco.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

