### PR TITLE
cda-validator: Agrega informa HTML de Castro Rendon

### DIFF
--- a/cda-validator/controller/queries/hpn.ts
+++ b/cda-validator/controller/queries/hpn.ts
@@ -35,7 +35,9 @@ function make(paciente: any) {
     Medicos.nombre as profesionalNombre,
     Medicos.apellido as profesionalApellido,
     Medicos.matriculaProvincial as profesionalMatricula,
-    url = 'http://${connectionString.webservice_host}/dotnet/ws/services/webservice.asmx/Informe?idEstudio=P-' + CONVERT(varchar(max), Prestaciones.id)
+    url = 'http://${connectionString.webservice_host}/dotnet/ws/services/webservice.asmx/Informe?idEstudio=P-' + CONVERT(varchar(max), Prestaciones.id),
+    (case when idTipo = 705 or idTipo = 901 then (SELECT dbo.hsp_Prestaciones_RegistroConsultorio_CDA(Prestaciones.id)) else null end) as informeHtml,
+    idTipo as PrestacionTipo
     -- Tablas
     FROM Prestaciones
     INNER JOIN Prestaciones_Tipos ON idTipo = Prestaciones_Tipos.id

--- a/cda-validator/controller/verificaCDA.ts
+++ b/cda-validator/controller/verificaCDA.ts
@@ -171,18 +171,26 @@ export async function verificar(registro, pacienteAndes) {
     }
 
 
-    // No Obligatorio
-    if (notError) {
-        // Por ahora este ws sólo lo devuelve HPN
-        if (registro.url) {
-            dto['file'] = await getInforme(registro.url);
-        }
-    }
-
     // NO Obligatorios
     if (notError) {
         dto['texto'] = registro.texto ? registro.texto : null;
     }
+
+    // No Obligatorio
+    if (notError) {
+        // Por ahora este ws sólo lo devuelve HPN
+        if (registro.url) {
+            // Si viene informeHtml es una prestacion de medicina clinica o pediatria
+            if (registro.informeHtml) {
+                dto['texto'] = registro.informeHtml;
+            } else if (registro.PrestacionTipo === 705 || registro.PrestacionTipo === 901) { // si no esta el informe esta mal la prestacion
+                notError = false;
+            } else { // Caso contrario se busca el PDF
+                dto['file'] = await getInforme(registro.url);
+            }
+        }
+    }
+
 
     if (!notError) {
         dto = null;

--- a/cda-validator/package-lock.json
+++ b/cda-validator/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "patient-validator",
-  "version": "1.0.0",
+  "name": "cda-validator",
+  "version": "12.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cda-validator/package.json
+++ b/cda-validator/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "patient-validator",
-  "version": "1.0.0",
+  "name": "cda-validator",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Requerimiento
* Informe de clinica medica y pediatria para el castro rendon. 

### Funcionalidad desarrollada
1. Se ejecuta una función SQL cuando es una prestación de clínica médica o pediatría del castro. No hay informe PDF.


### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No
