### PR TITLE
Bi-Queries: Error al querer enviar mas de un argumento de tipo id

### DIFF
--- a/bi-queries/controller/pipeline-builder.ts
+++ b/bi-queries/controller/pipeline-builder.ts
@@ -40,6 +40,9 @@ export function createPipeline(queryData: IQuery, params: IParams[]) {
 function replaceQuery(pipeline, argumento, valor, innerQuery = false) {
     if (Array.isArray(pipeline)) {
         return pipeline.map(item => replaceQuery(item, argumento, valor, innerQuery));
+    } else if (pipeline instanceof Types.ObjectId) {
+        return pipeline;
+
     } else if (typeof pipeline === 'object') {
         for (const key in pipeline) {
             if (argumento.subquery && key === '#' + argumento.key && !innerQuery) {


### PR DESCRIPTION
### Requerimiento
Error al querer enviar mas de un argumento de tipo id

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega un control en la función _replaceQuery_ para que al enviarse mas de un argumento de tipo id, lo reconozca y realice correctamente el reemplazo.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No
