### PR TITLE
feat(cda-validator): cachea ultima fecha

### DIFF
--- a/cda-validator/controller/ejecutaCDA.ts
+++ b/cda-validator/controller/ejecutaCDA.ts
@@ -11,12 +11,10 @@ export async function ejecutar(efector: string, factory, paciente, cleanCache) {
         let pool = await sql.connect(data.connectionString);
         let resultado = await getData(pool, data.query);
         const registros = resultado.recordset;
-        console.log(efector, cachePacienteFecha[efector + '-' + paciente.id]);
         if (registros.length > 0) {
             let ps = registros.map(async registro => {
                 let dto = await Verificator.verificar(registro, paciente);
                 if (dto && (checkCache(efector, paciente, dto.fecha) || cleanCache)) {
-                    console.log('HAGO POST');
                     await postCDA(dto);
                 }
             });

--- a/cda-validator/index.ts
+++ b/cda-validator/index.ts
@@ -16,22 +16,24 @@ router.group('/cda', (group) => {
         const webhookId = req.body.subscription;
         const event = req.body.event;
         const data = req.body.data;
-
         let paciente;
         switch (event) {
             case 'mobile:patient:login':
                 paciente = data.pacientes[0];
                 break;
+            case 'mpi:patient:update':
+            case 'mpi:patient:create':
+                paciente = data;
+                break;
             default:
                 paciente = data.paciente;
                 break;
         }
-
         if (paciente) {
             const invalidarCache = event === 'monitoreo:cda:create'; // un hack por ahora
             for (const efector of efectores) {
                 const factory = queries(efector, paciente);
-                await ejecutaCDA.ejecutar(factory, paciente, invalidarCache);
+                await ejecutaCDA.ejecutar(efector, factory, paciente, invalidarCache);
             }
         }
     });

--- a/cda-validator/index.ts
+++ b/cda-validator/index.ts
@@ -28,9 +28,10 @@ router.group('/cda', (group) => {
         }
 
         if (paciente) {
+            const invalidarCache = event === 'monitoreo:cda:create'; // un hack por ahora
             for (const efector of efectores) {
                 const factory = queries(efector, paciente);
-                await ejecutaCDA.ejecutar(factory, paciente);
+                await ejecutaCDA.ejecutar(factory, paciente, invalidarCache);
             }
         }
     });

--- a/cda-validator/package-lock.json
+++ b/cda-validator/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cda-validator",
-  "version": "12.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,7 +20,7 @@
       "dependencies": {
         "accepts": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
@@ -28,11 +28,11 @@
         },
         "array-flatten": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "body-parser": {
           "version": "1.18.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "bytes": "3.0.0",
             "content-type": "~1.0.4",
@@ -58,31 +58,31 @@
         },
         "buffer-equal-constant-time": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "bytes": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "content-disposition": {
           "version": "0.5.2",
-          "bundled": true
+          "resolved": false
         },
         "content-type": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "cookie": {
           "version": "0.3.1",
-          "bundled": true
+          "resolved": false
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "bundled": true
+          "resolved": false
         },
         "debug": {
           "version": "3.2.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ms": "^2.1.1"
           },
@@ -96,38 +96,38 @@
         },
         "depd": {
           "version": "1.1.2",
-          "bundled": true
+          "resolved": false
         },
         "destroy": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "ecdsa-sig-formatter": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "ee-first": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "encodeurl": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "escape-html": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false
         },
         "etag": {
           "version": "1.8.1",
-          "bundled": true
+          "resolved": false
         },
         "express": {
           "version": "4.16.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "accepts": "~1.3.5",
             "array-flatten": "1.1.1",
@@ -239,7 +239,7 @@
         },
         "finalhandler": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -267,15 +267,15 @@
         },
         "forwarded": {
           "version": "0.1.2",
-          "bundled": true
+          "resolved": false
         },
         "fresh": {
           "version": "0.5.2",
-          "bundled": true
+          "resolved": false
         },
         "http-errors": {
           "version": "1.6.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -285,26 +285,26 @@
         },
         "http-status-codes": {
           "version": "1.3.0",
-          "bundled": true
+          "resolved": false
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": false
         },
         "ipaddr.js": {
           "version": "1.8.0",
-          "bundled": true
+          "resolved": false
         },
         "jsonwebtoken": {
           "version": "8.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "jws": "^3.1.5",
             "lodash.includes": "^4.3.0",
@@ -326,7 +326,7 @@
         },
         "jwa": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "buffer-equal-constant-time": "1.0.1",
             "ecdsa-sig-formatter": "1.0.10",
@@ -335,7 +335,7 @@
         },
         "jws": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "jwa": "^1.1.5",
             "safe-buffer": "^5.0.1"
@@ -343,81 +343,81 @@
         },
         "lodash.includes": {
           "version": "4.3.0",
-          "bundled": true
+          "resolved": false
         },
         "lodash.isboolean": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": false
         },
         "lodash.isinteger": {
           "version": "4.0.4",
-          "bundled": true
+          "resolved": false
         },
         "lodash.isnumber": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": false
         },
         "lodash.isplainobject": {
           "version": "4.0.6",
-          "bundled": true
+          "resolved": false
         },
         "lodash.isstring": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false
         },
         "lodash.once": {
           "version": "4.1.1",
-          "bundled": true
+          "resolved": false
         },
         "media-typer": {
           "version": "0.3.0",
-          "bundled": true
+          "resolved": false
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "methods": {
           "version": "1.1.2",
-          "bundled": true
+          "resolved": false
         },
         "mime": {
           "version": "1.4.1",
-          "bundled": true
+          "resolved": false
         },
         "mime-db": {
           "version": "1.36.0",
-          "bundled": true
+          "resolved": false
         },
         "mime-types": {
           "version": "2.1.20",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mime-db": "~1.36.0"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "negotiator": {
           "version": "0.6.1",
-          "bundled": true
+          "resolved": false
         },
         "on-finished": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ee-first": "1.1.1"
           }
         },
         "parseurl": {
           "version": "1.3.2",
-          "bundled": true
+          "resolved": false
         },
         "passport": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "passport-strategy": "1.x.x",
             "pause": "0.0.1"
@@ -425,7 +425,7 @@
         },
         "passport-jwt": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "jsonwebtoken": "^8.2.0",
             "passport-strategy": "^1.0.0"
@@ -433,19 +433,19 @@
         },
         "passport-strategy": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "bundled": true
+          "resolved": false
         },
         "pause": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false
         },
         "proxy-addr": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "forwarded": "~0.1.2",
             "ipaddr.js": "1.8.0"
@@ -453,15 +453,15 @@
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true
+          "resolved": false
         },
         "range-parser": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false
         },
         "raw-body": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "bytes": "3.0.0",
             "http-errors": "1.6.3",
@@ -471,19 +471,19 @@
         },
         "require-dir": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": false
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false
         },
         "send": {
           "version": "0.16.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -517,7 +517,7 @@
         },
         "serve-static": {
           "version": "1.13.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
@@ -527,15 +527,15 @@
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "statuses": {
           "version": "1.5.0",
-          "bundled": true
+          "resolved": false
         },
         "type-is": {
           "version": "1.6.16",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.18"
@@ -543,19 +543,19 @@
         },
         "typescript": {
           "version": "2.9.2",
-          "bundled": true
+          "resolved": false
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "utils-merge": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "vary": {
           "version": "1.1.2",
-          "bundled": true
+          "resolved": false
         }
       }
     },

--- a/cda-validator/package.json
+++ b/cda-validator/package.json
@@ -4,9 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "lint": "tslint --project ..",
+    "start": "../node_modules/concurrently/bin/concurrently.js -r \"npm run tsc:w\" \"npm run node\" ",
+    "lint": "tslint --project .",
     "tsc": "../node_modules/typescript/bin/tsc",
-    "tsc:w": "../node_modules/typescript/bin/tsc -w"
+    "tsc:w": "../node_modules/typescript/bin/tsc -w",
+    "node": "nodemon -q ./index.js"
   },
   "author": "",
   "license": "ISC",

--- a/cda-validator/tsconfig.json
+++ b/cda-validator/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tsconfig.json",
+    "include": [
+        "**/*.ts"
+    ]
+}


### PR DESCRIPTION
### Funcionalidad desarrollada 
1. Guarda en memoria la ultima fecha sincronizada del paciente, para no hacer el POST de nuevo.
2. Si viene desde monitoreo ejecuta todo igual.

La idea es hacer lo mismo en laboratorio y bajar la cantidad de POST reiterados. 
Arrancamos por cache en memoria, despues podría quedar persisitido en algún lugar. 

![image](https://user-images.githubusercontent.com/3813270/95906065-ff425400-0d6f-11eb-8037-424e764e485a.png)


### UserStory llegó a completarse
- [ ] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
