### PR TITLE
SIP-Plus:se agregan varios mapeos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ _____________________________________________
 
 -->
 ### Requerimiento
-* URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento
+<!-- * URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
 
 ### Funcionalidad desarrollada 
 <!-- Describir que se desarrollo -->

--- a/facturacion/index.ts
+++ b/facturacion/index.ts
@@ -16,7 +16,6 @@ router.group('/facturacion', (group) => {
 
     group.post('/facturar', async (req, res) => {
         try {
-            console.log("Entra a facturar");
             sql.close();
             let pool = await sql.connect(SipsDBConfiguration);
             const event = req.body.event;

--- a/sip-plus-perinatal/controller/sip-plus.ts
+++ b/sip-plus-perinatal/controller/sip-plus.ts
@@ -291,7 +291,7 @@ async function createMatchSnomed(registros: any[], embActual, newDatosEmb) {
         const arrayId = registros.map(cId => cId.concepto.conceptId);
         const arrayCode = Object.keys(embActual);
         const matchEmbarazo = await getMatching('snomed');
-        // obtengo todos los conceptos definidos por BD que matchean con los recibidos de la prestación
+        // obtengo todos los conceptos definidos por BD que coincidan con los recibidos de la prestación
         // y que no se encuentren ya cargados en el embarazo
         const idsMatched = matchEmbarazo.filter(cId => (arrayId.includes(cId.concepto.conceptId) &&
             (!arrayCode.includes(cId.sipPlus.code))));
@@ -360,10 +360,13 @@ async function mappingSnomed(matchPrenatal: IPerinatal[], registros: any[], newD
         const reg = registros.find(reg => reg.concepto.conceptId === idMatch.concepto.conceptId);
         if (reg && reg.valor) {
             const type = idMatch.sipPlus.type.toUpperCase();
-            let valorSP =
-                (type === 'DATE') ? moment(reg.valor.toString()).format('DD/MM/YY') :
-                    (type === 'NUMERIC') ? mappingNumeric(reg.valor, idMatch) :
-                        null;
+            let valorSP = null;
+            if (type === 'DATE') {
+                valorSP = moment(reg.valor.toString()).format('DD/MM/YY');
+            }
+            if (type === 'NUMERIC') {
+                valorSP = mappingNumeric(reg.valor, idMatch);
+            }
             if (type === 'TEXT') {
                 let arrayKeyValor = Object.keys(reg.valor);
                 if (arrayKeyValor.length) {
@@ -395,6 +398,11 @@ function mappingNumeric(valor: any, match: IPerinatal) {
             const unidad = match.sipPlus.extra.unidad || 1;
             valorCast = valorCast * parseFloat(unidad) * Math.pow(parseInt(base, 10), parseInt(potencia, 10));
 
+        }
+        //ver para que funcione con la talla de replicar esto para el otro mapping de NUMERIC asi todos usan esta función
+        if (operation && operation.toString().toLowerCase() === 'resta') {
+            const unidad = match.sipPlus.extra.unidad || 0;
+            valorCast = valorCast - unidad;
         }
         valorSP = parseInt(valorCast.toString(), 10);
     }

--- a/sip-plus-perinatal/schemas/perinatal.ts
+++ b/sip-plus-perinatal/schemas/perinatal.ts
@@ -11,6 +11,7 @@ export type IPerinatal = {
     sipPlus: {
         code: string,
         type: string,
+        extra?: any,
         valor?: any
     },
     concepto?: ISnomedConcept,

--- a/sip-plus-perinatal/service/matchPerinatal.ts
+++ b/sip-plus-perinatal/service/matchPerinatal.ts
@@ -34,6 +34,9 @@ export async function getMatching(tipoMatch = null) {
                 if (elemMap['sourceValue']['valor']) {
                     dataMap.sipPlus.valor = elemMap['targetValue']['valor'];
                 }
+                if (elemMap['targetValue']['extra']) {
+                    dataMap.sipPlus.extra = elemMap['targetValue']['extra'];
+                }
             }
             return dataMap;
         });

--- a/sip-plus-perinatal/service/organizacion.ts
+++ b/sip-plus-perinatal/service/organizacion.ts
@@ -1,0 +1,26 @@
+import { ANDES_HOST, ANDES_KEY, fakeRequest } from '../config.private';
+const fetch = require('node-fetch');
+
+import { log } from '@andes/log';
+
+export async function getOrganizacionAndes(idOrganizacion) {
+    const url = `${ANDES_HOST}/core/tm/organizaciones?ids=${idOrganizacion}`;
+    const options = {
+        url,
+        method: 'GET',
+        headers: {
+            Authorization: `JWT ${ANDES_KEY}`
+        }
+    };
+    try {
+        let response = await fetch(url, options);
+
+        const responseJson = await response.json();
+
+        return responseJson[0] || null;
+    }
+    catch (error) {
+        log(fakeRequest, 'microservices:integration:sip-plus', idOrganizacion, 'getOrganizacionAndes:error', error);
+    }
+
+}


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados
  
2) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
3) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/PER-29
https://proyectos.andes.gob.ar/browse/PER-30
 Se agrega especificaciones optativas en los mapeos de Snomed.
 Agrega organización en "Lugar de control prenatal".
 
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agrega especificación por unidad de medida para mapeo de numeros. Ejemplo para peso entre kg y gr, lb, etc.
2. Se agrega especificación de operación "resta" para ciertos mapeos que lo requieren. Ej: altura paciente en Rup 170cm => sip-plus 70.
3. Agrega el dato de organización obtenido de la prestación al momento de crear una nueva ficha (registro nuevo embarazo) en "Lugar de control prenatal"


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

Nuevos datos en la BD:
1. Para poder mapear la organización al abrir una nueva ficha es necesario que en la colección "organizaciones" (codigo) se contenga el dato de "subdivisionId" de cada organización.
2. Para poder aplicar la conversión de números especificar en la colección "queries_mapping" en "targetValue" la operacion. Ejemplo entre kg y gr: 26kg => 26000 gr = 26 * 10(pot 3)
        "extra" : {
            "operation" : "cast-unidad",
            "floor" : 10,
            "potency" : 3
        }
Si se quiere usar una conversion entre tipos distintos (ejemplo de libra a kilo) se puede agregar "unidad" : 0.45, especificando la el valor de la conversión por una unidad (1libra => 0.45 kg)
Ejemplo de peso usado en sip-plus para registro de un control de embarazo:
```
db.getCollection('queries_mapping').insertMany([
{
    "source" : "andes:snomed-prenatal",
    "sourceValue" : {
        "key" : "peso",
        "concepto" : {
            "conceptId" : "27113001",
            "term" : "peso corporal",
            "fsn" : "peso corporal (entidad observable)",
            "refsetIds" : [ 
                "900000000000497000"
            ],
            "semanticTag" : "entidad observable"
        }
    },
    "target" : "sip+",
    "targetValue" : {
        "code" : "0120",
        "type" : "NUMERIC",
        "extra" : {
            "operation" : "cast-unidad",
            "unidad" : 1,
            "floor" : 10,
            "potency" : 1
        }
    }
}
])
```

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
