### PR TITLE
BI: doble validacion de objectId

### DIFF
--- a/bi-queries/controller/pipeline-builder.ts
+++ b/bi-queries/controller/pipeline-builder.ts
@@ -9,7 +9,7 @@ export function createPipeline(queryData: IQuery, params: IParams[]) {
         if (v) {
             if (arg.tipo === 'date') {
                 v.valor = moment(v.valor).toDate();
-            } else if (Types.ObjectId.isValid(v.valor)) {
+            } else if (Types.ObjectId.isValid(v.valor) && new Types.ObjectId(v.valor).toString() === v.valor) {
                 v.valor = new Types.ObjectId(v.valor);
             }
         }


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados
  
2) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
3) Completar las siguientes secciones:

-->
### Requerimiento
<!-- * URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
Laboratorio central reporta fallas en la consulta de fichas por identificador de PCR.
En el pipe builder, algunos parámetros pasan la validación de objectId sin serlo (en este caso, identificador de PCR). Esto repercute que algunos match de parámetros falle.
Se agrega doble validación de objectId.
https://stackoverflow.com/questions/13850819/can-i-determine-if-a-string-is-a-mongodb-objectid
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
