### PR TITLE
Sip-plus: quita conceptId de la fecha próximo control

### DIFF
--- a/sip-plus-perinatal/controller/sip-plus.ts
+++ b/sip-plus-perinatal/controller/sip-plus.ts
@@ -346,18 +346,20 @@ async function createMatchControl(registros: any[], embActual, newDatosEmb, fech
                 const numCtrl = (arrayKeys.length) ? (Math.max.apply(null, arrayKeys) + 1).toString() : '1';
                 // obtengo todos los conceptos definidos por BD que matchean con los recibidos de la prestación
                 let matchPrenatal: IPerinatal[] = await getMatching('snomed-prenatal');
-                const proxCtrl = registros.find(reg => reg.concepto.conceptId === '390840006');
+                // obtenemos el concepto asociado al día del próximo control
+                const dia = matchPrenatal.find(elem => elem.key.includes('dia-proximo-turno'));
+                const conceptIdProxCtrol = (dia && dia.concepto) ? dia.concepto.conceptId : null;
+                const proxCtrl = conceptIdProxCtrol ? registros.find(reg => reg.concepto.conceptId === conceptIdProxCtrol) : null;
                 let newCtrl = {
                     '0116': fechaControl
                 };
                 // completamos los datos del próximo control (día y mes)
                 if (proxCtrl && proxCtrl.valor) {
-                    const dia = matchPrenatal.find(elem => elem.concepto.conceptId === '390840006' && elem.key.includes('dia-proximo-turno'));
-                    const mes = matchPrenatal.find(elem => elem.concepto.conceptId === '390840006' && elem.key.includes('mes-proximo-turno'));
+                    const mes = matchPrenatal.find(elem => elem.key.includes('mes-proximo-turno'));
                     newCtrl[dia.sipPlus.code] = moment(proxCtrl.valor).date();
                     newCtrl[mes.sipPlus.code] = moment(proxCtrl.valor).month() + 1;
                     // eliminamos los registros ya mappeados
-                    matchPrenatal = matchPrenatal.filter(elemMatch => elemMatch.concepto.conceptId !== '390840006');
+                    matchPrenatal = matchPrenatal.filter(elemMatch => elemMatch.concepto.conceptId !== conceptIdProxCtrol);
                 }
                 newCtrl = await mappingSnomed(matchPrenatal, registros, newCtrl);
 


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados
  
2) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
3) Completar las siguientes secciones:

-->
### Requerimiento
<!-- * URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
Para poder modificar el concepto asociado a la  "fecha de proximo control" solo desde la BD, se elimina el uso por conceptId  desde el código.
Importante! Es necesario que exista solo un elemento en la colección queries mapping asociado al  "dia-proximo-turno" .

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se elimina el uso por conceptId para "fecha de proximo control" desde el código.
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [X] Si, https://github.com/andes/api/pull/1472
- [ ] No

Modificar el concepto asociado a en la coleccion de queries_mapping con "dia-proximo-turno" y "mes-proximo-turno" por el nuevo concepto de la fecha.
```
db.getCollection('queries_mapping').find({
    'sourceValue.key':/proximo-turno/i,
    "source":"andes:snomed-prenatal"
    })
``````

"concepto" : {
            "conceptId" : "2471000246107",
            "term" : "fecha sugerida de la próxima visita",
            "fsn" : "fecha sugerida de la próxima visita (entidad observable) ",
            "semanticTag" : "entidad observable"
        }
```


